### PR TITLE
Update bower.json to use Polymer 1.2.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "preview.png"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#~1.1.4",
+    "polymer": "Polymer/polymer#~1.2.4",
     "jsoneditor": "josdejong/jsoneditor#^4.2.1",
     "fast-json-patch": "~0.5.2"
   },


### PR DESCRIPTION
Tested it to work with Polymer 1.2.4.
Version uptick to avoid ugly dependency conflict when doing bower install or bower update.